### PR TITLE
output name of project that is missing

### DIFF
--- a/dolly/config.py
+++ b/dolly/config.py
@@ -47,7 +47,7 @@ class Config:
 
 	def parse(self, name):
 		if not (name in self.data):
-			terminal.error("Project doesn't exist in config file")
+			terminal.error("Project " + name + " doesn't exist in config file")
 			sys.exit(0)
 		proj = self.data[name]
 		tree = []


### PR DESCRIPTION
When the execution stops the error message should point out the name of the project that lead to the failure. Otherwise the user doesn't know what is wrong in the config file.